### PR TITLE
Fix asking for text fields when they still hold the empty string

### DIFF
--- a/common.spec.js
+++ b/common.spec.js
@@ -11,7 +11,13 @@ describe('Common tests', function() {
     beforeAll(function() {
         browser.get("#!/status");
         browser.wait(EC.visibilityOf(common.serverTime), 100000);
+        browser.wait(EC.visibilityOf(common.stage), 10000);
         cookiebar.closeIfPresent();
+        // Wait until all text fields have there text set (no longer empty string). We test this
+        // by waiting for the last text field, which we assume to be the otap stage.
+        browser.wait(function() {return common.stage.getText().then(function(text) {
+            return text != ""
+        })}, 10000)
     });
 
     it("Should display the correct date in the upper right", function() { 
@@ -22,9 +28,7 @@ describe('Common tests', function() {
         if(dd<10) dd='0'+dd;
         if(mm<10) mm='0'+mm;
         today = yyyy+'-'+mm+'-'+dd;
-
         browser.waitForAngularEnabled(false);
-        browser.sleep(300)
         common.serverTime.getText().then(function(text){
             expect(text).toContain(today);
         });

--- a/common.spec.js
+++ b/common.spec.js
@@ -10,7 +10,6 @@ describe('Common tests', function() {
 
     beforeAll(function() {
         browser.get("#!/status");
-        browser.wait(EC.visibilityOf(common.serverTime), 100000);
         browser.wait(EC.visibilityOf(common.stage), 10000);
         cookiebar.closeIfPresent();
         // Wait until all text fields have there text set (no longer empty string). We test this

--- a/components/common.component.js
+++ b/components/common.component.js
@@ -4,6 +4,7 @@ var Common = function () {
     this.feedbackClose = this.feedbackModal.element(by.css("button.btn.btn-white"));
 
     this.serverTime = element(by.binding("serverTime"));
+    this.stage = element.all(by.className("m-r-sm stage")).get(0);
 };
 
 module.exports = Common;


### PR DESCRIPTION
Fix the protractor test. The Frank!Console presents text fields like the current date and the DTAP stage. These elements become visible before they are properly initialized. This fix waits until the last text field is no longer the empty string.