### PR TITLE
Failed attempt to test opening report in test tab

### DIFF
--- a/ladybug.spec.js
+++ b/ladybug.spec.js
@@ -8,6 +8,8 @@ describe('Ladybug Page tests', function(){
 	let testPipelinePage = new TestPipelinePage();
 	let cookiebar = new CookieBar();
 
+	let reportTableRowsHeaderCount = 2;
+
 	function testAPipeline(message) {
 		browser.get('#!/test-pipeline');
 		browser.waitForAngularEnabled(true);
@@ -50,34 +52,6 @@ describe('Ladybug Page tests', function(){
 		ladybug.enableReportGenerator();
 		teardown();
 	})
-
-	it('Should be able to open report in Test tab', function() {
-		ladybug.testTab.click();
-		ladybug.refreshTab.click();
-		ladybug.reportList.count().then(function(result) {
-			console.log("Number of reports: " + result);
-			if(result >= 1) {
-				browser.wait(EC.elementToBeClickable(ladybug.selectAllTab));
-				ladybug.selectAllTab.click();
-				ladybug.deleteTab.click();
-				browser.wait(EC.elementToBeClickable(ladybug.confirmDelete), 3000);
-				ladybug.confirmDelete.click();
-				ladybug.debugTab.click();
-			}
-		});
-		testAPipeline('Protractor test for error message');
-		// select the first pipeline report from "Reports"
-		browser.wait(EC.presenceOf(ladybug.report), 3000);
-		ladybug.report.click();
-		// copy the report
-		browser.wait(EC.elementToBeClickable(ladybug.copyTab), 3000);
-		ladybug.copyTab.click();
-		ladybug.testTab.click();
-		ladybug.refreshTab.click();
-		ladybug.reportList.count().then(function(result) {
-			ladybug.testTabFirstReportOpen.click();
-		});
-	});
 
 	it('When I enable the report generator, test a pipeline and then refresh, should appear a new report in the storage ', function() {
 		ladybug.refreshDebug.click();
@@ -144,8 +118,8 @@ describe('Ladybug Page tests', function(){
 		// go to "Test" tab
 		ladybug.testTab.click();
 		// click on "Select all" and then "Delete", so can locate the new report
-		ladybug.reportList.count().then(function(result) {
-			if(result > 2) {
+		ladybug.reportTableRows.count().then(function(result) {
+			if(result - reportTableRowsHeaderCount > 2) {
 				ladybug.selectAllTab.click();
 				ladybug.deleteTab.click();
 				browser.wait(EC.elementToBeClickable(ladybug.confirmDelete), 3000);
@@ -162,5 +136,49 @@ describe('Ladybug Page tests', function(){
 		ladybug.errorMessage.getText().then(function(text) {
 			expect(text).toContain('Result report not found. Report generator not enabled?');
 		});
+	});
+
+	it('Should be able to open report in Test tab', function() {
+		ladybug.testTab.click();
+		ladybug.refreshTab.click();
+		ladybug.reportTableRows.count().then(function(result) {
+			if(result - reportTableRowsHeaderCount >= 1) {
+				console.log('Deleting old reports');
+				browser.wait(EC.elementToBeClickable(ladybug.selectAllTab));
+				ladybug.selectAllTab.click();
+				ladybug.deleteTab.click();
+				browser.wait(EC.elementToBeClickable(ladybug.confirmDelete), 3000);
+				ladybug.confirmDelete.click();
+				ladybug.debugTab.click();
+			}
+		});
+		testAPipeline('Protractor test for error message');
+		// select the first pipeline report from "Reports"
+		browser.wait(EC.presenceOf(ladybug.report), 3000);
+		browser.sleep(3000);
+		ladybug.report.click();
+		// copy the report
+		browser.wait(EC.elementToBeClickable(ladybug.copyTab), 3000);
+		ladybug.copyTab.click();
+		ladybug.testTab.click();
+		ladybug.refreshTab.click();
+		ladybug.reportTableRows.count().then(function(result) {
+			if(result - reportTableRowsHeaderCount >= 2) {
+				console.log("After deleting all reports and creating one, have " + result);
+				expect(false);
+			}
+			ladybug.testTabFirstReportOpen.click();
+		});
+		console.log("Report should have been opened. Checking whether that has happened");
+		/*
+		browser.wait(EC.presenceOf(ladybug.textOpenedFirstReport));
+		console.log("Have presence of HTML element");
+		ladybug.textOpenedFirstReport.getText().then(text => {
+			console.log('Have the text');
+			expect(text).toEqual('Protractor test for error message');
+			console.log('Checked the text');
+		});
+		*/
+		ladybug.testTab.click();
 	});
 });

--- a/ladybug.spec.js
+++ b/ladybug.spec.js
@@ -15,6 +15,7 @@ describe('Ladybug Page tests', function(){
 		browser.get('#!/testing/ladybug');
 		browser.switchTo().frame(ladybug.iframe.getWebElement());
 		browser.waitForAngularEnabled(false);
+		ladybug.debugTab.click();
 		ladybug.refreshDebug.click();
 		browser.sleep(300);
 		ladybug.firstReportInStorage.click();
@@ -49,6 +50,34 @@ describe('Ladybug Page tests', function(){
 		ladybug.enableReportGenerator();
 		teardown();
 	})
+
+	it('Should be able to open report in Test tab', function() {
+		ladybug.testTab.click();
+		ladybug.refreshTab.click();
+		ladybug.reportList.count().then(function(result) {
+			console.log("Number of reports: " + result);
+			if(result >= 1) {
+				browser.wait(EC.elementToBeClickable(ladybug.selectAllTab));
+				ladybug.selectAllTab.click();
+				ladybug.deleteTab.click();
+				browser.wait(EC.elementToBeClickable(ladybug.confirmDelete), 3000);
+				ladybug.confirmDelete.click();
+				ladybug.debugTab.click();
+			}
+		});
+		testAPipeline('Protractor test for error message');
+		// select the first pipeline report from "Reports"
+		browser.wait(EC.presenceOf(ladybug.report), 3000);
+		ladybug.report.click();
+		// copy the report
+		browser.wait(EC.elementToBeClickable(ladybug.copyTab), 3000);
+		ladybug.copyTab.click();
+		ladybug.testTab.click();
+		ladybug.refreshTab.click();
+		ladybug.reportList.count().then(function(result) {
+			ladybug.testTabFirstReportOpen.click();
+		});
+	});
 
 	it('When I enable the report generator, test a pipeline and then refresh, should appear a new report in the storage ', function() {
 		ladybug.refreshDebug.click();
@@ -106,7 +135,7 @@ describe('Ladybug Page tests', function(){
 		testAPipeline('Protractor test for error message');
 		// select the first pipeline report from "Reports"
 		browser.wait(EC.presenceOf(ladybug.report), 3000);
-		ladybug.report.click();	
+		ladybug.report.click();
 		// copy the report
 		browser.wait(EC.elementToBeClickable(ladybug.copyTab), 3000);
 		ladybug.copyTab.click();

--- a/pages/ladybug.page.js
+++ b/pages/ladybug.page.js
@@ -21,7 +21,8 @@ var LadybugPage = function() {
 		.element(by.tagName('tbody'))
 		.element(by.tagName('tr'))
 		.all(by.css('td:nth-child(2)'));
-
+	expectedText = 'Protractor test for error message';
+	this.textOpenedFirstReport = element(by.xpath("//span[contains(., '" + expectedText + "')]"));
 	this.enableReportGenerator = function() {
 		this.optionsTab.click();
 		this.enableGeneratorOption.click();		
@@ -38,7 +39,7 @@ var LadybugPage = function() {
 	this.debugTab = element(by.id('c_10_header_td_11'));
 	this.selectAllTab = element(by.id('c_235_cell_c_240'));
 	this.refreshTab = element(by.id('c_235_cell_c_236'));
-	this.reportList = element(by.id('c_963')).all(by.xpath('table/tbody/tr'));
+	this.reportTableRows = element(by.id('c_234')).all(by.tagName('div'));
 	this.deleteTab = element(by.id('c_235_cell_c_245'));
 	this.confirmDelete = element(by.cssContainingText('tr','No, cancel this action')).element(by.css("td:nth-child(1)"));
 	this.runTab = element(by.id('c_235_cell_c_237'));

--- a/pages/ladybug.page.js
+++ b/pages/ladybug.page.js
@@ -17,7 +17,11 @@ var LadybugPage = function() {
 	this.pipelineMessage = element(by.css('[valign="top"]'));
 	this.enableGeneratorOption = element(by.id('c_64_item_0'));
 	this.disableGeneratorOption = element(by.id('c_64_item_1'));
-	
+	this.testTabFirstReportOpen = element(by.tagName('table'))
+		.element(by.tagName('tbody'))
+		.element(by.tagName('tr'))
+		.all(by.css('td:nth-child(2)'));
+
 	this.enableReportGenerator = function() {
 		this.optionsTab.click();
 		this.enableGeneratorOption.click();		
@@ -34,7 +38,7 @@ var LadybugPage = function() {
 	this.debugTab = element(by.id('c_10_header_td_11'));
 	this.selectAllTab = element(by.id('c_235_cell_c_240'));
 	this.refreshTab = element(by.id('c_235_cell_c_236'));
-	this.reportList = element(by.id('c_234')).all(by.xpath('div/div'));
+	this.reportList = element(by.id('c_963')).all(by.xpath('table/tbody/tr'));
 	this.deleteTab = element(by.id('c_235_cell_c_245'));
 	this.confirmDelete = element(by.cssContainingText('tr','No, cancel this action')).element(by.css("td:nth-child(1)"));
 	this.runTab = element(by.id('c_235_cell_c_237'));


### PR DESCRIPTION
This was a trial to test that a report can be opened in the Ladybug Test tab. The attempt failed because the list of report is organized differently depending on the number of reports. If there is one report, element id c_234 contains a table that has the reports. When there are two reports there are <div> elements, one for each report and two extra to hold buttons and a search field.