### PR TITLE
Fixing tests

### DIFF
--- a/ladybug.spec.js
+++ b/ladybug.spec.js
@@ -15,8 +15,11 @@ describe('Ladybug Page tests', function(){
 		browser.get('#!/testing/ladybug');
 		browser.switchTo().frame(ladybug.iframe.getWebElement());
 		browser.waitForAngularEnabled(false);
+		let EC = protractor.ExpectedConditions;
+		browser.wait(EC.visibilityOf(ladybug.refreshDebug), 5000);
 		ladybug.refreshDebug.click();
-		browser.sleep(300);
+		browser.wait(EC.visibilityOf(ladybug.firstReportInStorage), 10000);
+		browser.sleep(5000);
 		ladybug.firstReportInStorage.click();
 	};
 

--- a/pages/ladybug.page.js
+++ b/pages/ladybug.page.js
@@ -31,7 +31,7 @@ var LadybugPage = function() {
 							
 	// Ladybug Test Page components
 	this.testTab = element(by.id('c_10_header_td_42'));
-	this.debugTab = element(by.id('c_10_header_td_11'));
+	this.debugTab = element(by.id('c_10_header_div_11'));
 	this.selectAllTab = element(by.id('c_235_cell_c_240'));
 	this.refreshTab = element(by.id('c_235_cell_c_236'));
 	this.reportList = element(by.id('c_234')).all(by.xpath('div/div'));

--- a/pages/test-pipeline.page.js
+++ b/pages/test-pipeline.page.js
@@ -1,11 +1,16 @@
 var TestPipelinePage = function() {
-	this.adapter = element(by.css('[value="HelloWorld"]'))
+	this.configuration = element(by.cssContainingText('option', 'Frank2Example'));
+	this.adapter = element(by.cssContainingText('option', 'HelloWorld'));
 	this.messageField = element(by.model('form.message'));
 	this.btnSend = element(by.buttonText("Send"));
 	this.result = element(by.exactBinding("result"));
 	this.alertMessage = element(by.css('[role="alert"]'));
 	
 	this.testPipeline = function(message){
+		this.configuration.click();
+		let EC = protractor.ExpectedConditions;
+		browser.wait(EC.elementToBeClickable(this.adapter), 10000);
+		browser.sleep(1000);
 		this.adapter.click();
 		this.messageField.sendKeys(message);
 		this.btnSend.click();	

--- a/test-pipeline.spec.js
+++ b/test-pipeline.spec.js
@@ -9,7 +9,7 @@ describe('Test A Pipeline Page tests', function() {
     beforeEach(function() {
 		browser.get("#!/test-pipeline");
 		//browser.sleep(1000);
-        browser.wait(EC.presenceOf(testPipelinePage.adapter), 100000);
+        browser.wait(EC.presenceOf(testPipelinePage.configuration), 10000);
         cookiebar.closeIfPresent();
     });
     


### PR DESCRIPTION
This does not work. I get the following errors:

```
1. Ladybug Page tests : When I enable the report generator, test a pipeline and then refresh, should appear a new report in the storage
   Failed: element click intercepted: Element <div id="c_10_header_div_11" style="overflow: hidden; white-space: nowrap; margin-top: 0px; border-width: 1px 1px 0px; border-style: solid solid none; border-top-color: rgb(0, 0, 79); border-left-color: rgb(0, 0, 79); border-right-color: rgb(0, 0, 79); border-bottom-color: initial; height: 26px; background-color: rgb(135, 160, 184); padding: 3px 8px; cursor: default; color: rgb(255, 255, 255);">...</div> is not clickable at point (40, 18). Other element would receive the click: <td>...</td>
     (Session info: headless chrome=108.0.5359.98)
     (Driver info: chromedriver=108.0.5359.71 (1e0e3868ee06e91ad636a874420e3ca3ae3756ac-refs/branch-heads/5359@{#1016}),platform=Windows NT 10.0.22000 x86_64)
    at point 40, 18. Other element would receive the click: <td>...</td>
       at Object.checkLegacyResponse C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\error.js:546:15
       at parseHttpResponse C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\http.js:509:13
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\http.js:441:30
       at runMicrotasks <anonymous>
       at processTicksAndRejections node:internal/process/task_queues:96:5
       at Driver.schedule C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:807:17
       at WebElement.schedule_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:2010:25
       at WebElement.click C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:2092:17
       at actionFn C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:89:44
       at Array.map <anonymous>
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:461:65
       at ManagedPromise.invokeCallback_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1376:14
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2927:27Error
       at ElementArrayFinder.applyAction_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:459:27
       at ElementArrayFinder.<computed> [as click] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:91:29
       at ElementFinder.<computed> [as click] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:831:22
       at UserContext.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:66:20
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:112:25
       at new ManagedPromise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1077:7
       at ControlFlow.promise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2505:12
       at schedulerExecute C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:95:18
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at UserContext.<anonymous> C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:94:19
       at Suite.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:49:2
       at Object.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:5:1
       at Module._compile node:internal/modules/cjs/loader:1101:14
       at Object.Module._extensions..js node:internal/modules/cjs/loader:1153:10
       at Module.load node:internal/modules/cjs/loader:981:32
       at Function.Module._load node:internal/modules/cjs/loader:822:12

2. Ladybug Page tests : When I disable the report generator, test a pipeline and then refresh, should not appear a new report in the storage
   Failed: element click intercepted: Element <div id="c_10_header_div_11" style="overflow: hidden; white-space: nowrap; margin-top: 0px; border-width: 1px 1px 0px; border-style: solid solid none; border-top-color: rgb(0, 0, 79); border-left-color: rgb(0, 0, 79); border-right-color: rgb(0, 0, 79); border-bottom-color: initial; height: 26px; background-color: rgb(135, 160, 184); padding: 3px 8px; cursor: default; color: rgb(255, 255, 255);">...</div> is not clickable at point (40, 18). Other element would receive the click: <td>...</td>
     (Session info: headless chrome=108.0.5359.98)
     (Driver info: chromedriver=108.0.5359.71 (1e0e3868ee06e91ad636a874420e3ca3ae3756ac-refs/branch-heads/5359@{#1016}),platform=Windows NT 10.0.22000 x86_64)
    at point 40, 18. Other element would receive the click: <td>...</td>
       at Object.checkLegacyResponse C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\error.js:546:15
       at parseHttpResponse C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\http.js:509:13
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\http.js:441:30
       at runMicrotasks <anonymous>
       at processTicksAndRejections node:internal/process/task_queues:96:5
       at Driver.schedule C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:807:17
       at WebElement.schedule_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:2010:25
       at WebElement.click C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:2092:17
       at actionFn C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:89:44
       at Array.map <anonymous>
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:461:65
       at ManagedPromise.invokeCallback_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1376:14
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2927:27Error
       at ElementArrayFinder.applyAction_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:459:27
       at ElementArrayFinder.<computed> [as click] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:91:29
       at ElementFinder.<computed> [as click] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:831:22
       at UserContext.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:66:20
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:112:25
       at new ManagedPromise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1077:7
       at ControlFlow.promise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2505:12
       at schedulerExecute C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:95:18
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at UserContext.<anonymous> C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:94:19
       at Suite.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:49:2
       at Object.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:5:1
       at Module._compile node:internal/modules/cjs/loader:1101:14
       at Object.Module._extensions..js node:internal/modules/cjs/loader:1153:10
       at Module.load node:internal/modules/cjs/loader:981:32
       at Function.Module._load node:internal/modules/cjs/loader:822:12

3. Ladybug Page tests : Should list the correct number of reports in the storage when input a number
   Failed: element click intercepted: Element <div id="c_10_header_div_11" style="overflow: hidden; white-space: nowrap; margin-top: 0px; border-width: 1px 1px 0px; border-style: solid solid none; border-top-color: rgb(0, 0, 79); border-left-color: rgb(0, 0, 79); border-right-color: rgb(0, 0, 79); border-bottom-color: initial; height: 26px; background-color: rgb(135, 160, 184); padding: 3px 8px; cursor: default; color: rgb(255, 255, 255);">...</div> is not clickable at point (40, 18). Other element would receive the click: <td>...</td>
     (Session info: headless chrome=108.0.5359.98)
     (Driver info: chromedriver=108.0.5359.71 (1e0e3868ee06e91ad636a874420e3ca3ae3756ac-refs/branch-heads/5359@{#1016}),platform=Windows NT 10.0.22000 x86_64)
    at point 40, 18. Other element would receive the click: <td>...</td>
       at Object.checkLegacyResponse C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\error.js:546:15
       at parseHttpResponse C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\http.js:509:13
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\http.js:441:30
       at runMicrotasks <anonymous>
       at processTicksAndRejections node:internal/process/task_queues:96:5
       at Driver.schedule C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:807:17
       at WebElement.schedule_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:2010:25
       at WebElement.click C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:2092:17
       at actionFn C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:89:44
       at Array.map <anonymous>
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:461:65
       at ManagedPromise.invokeCallback_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1376:14
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2927:27Error
       at ElementArrayFinder.applyAction_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:459:27
       at ElementArrayFinder.<computed> [as click] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:91:29
       at ElementFinder.<computed> [as click] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:831:22
       at UserContext.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:66:20
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:112:25
       at new ManagedPromise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1077:7
       at ControlFlow.promise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2505:12
       at schedulerExecute C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:95:18
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at UserContext.<anonymous> C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:94:19
       at Suite.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:49:2
       at Object.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:5:1
       at Module._compile node:internal/modules/cjs/loader:1101:14
       at Object.Module._extensions..js node:internal/modules/cjs/loader:1153:10
       at Module.load node:internal/modules/cjs/loader:981:32
       at Function.Module._load node:internal/modules/cjs/loader:822:12

4. Ladybug Page tests : Should show correct amount of reports when I click certain tabs
   Failed: element click intercepted: Element <div id="c_10_header_div_11" style="overflow: hidden; white-space: nowrap; margin-top: 0px; border-width: 1px 1px 0px; border-style: solid solid none; border-top-color: rgb(0, 0, 79); border-left-color: rgb(0, 0, 79); border-right-color: rgb(0, 0, 79); border-bottom-color: initial; height: 26px; background-color: rgb(135, 160, 184); padding: 3px 8px; cursor: default; color: rgb(255, 255, 255);">...</div> is not clickable at point (40, 18). Other element would receive the click: <td>...</td>
     (Session info: headless chrome=108.0.5359.98)
     (Driver info: chromedriver=108.0.5359.71 (1e0e3868ee06e91ad636a874420e3ca3ae3756ac-refs/branch-heads/5359@{#1016}),platform=Windows NT 10.0.22000 x86_64)
    at point 40, 18. Other element would receive the click: <td>...</td>
       at Object.checkLegacyResponse C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\error.js:546:15
       at parseHttpResponse C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\http.js:509:13
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\http.js:441:30
       at runMicrotasks <anonymous>
       at processTicksAndRejections node:internal/process/task_queues:96:5
       at Driver.schedule C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:807:17
       at WebElement.schedule_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:2010:25
       at WebElement.click C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:2092:17
       at actionFn C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:89:44
       at Array.map <anonymous>
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:461:65
       at ManagedPromise.invokeCallback_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1376:14
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2927:27Error
       at ElementArrayFinder.applyAction_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:459:27
       at ElementArrayFinder.<computed> [as click] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:91:29
       at ElementFinder.<computed> [as click] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\element.js:831:22
       at UserContext.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:66:20
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:112:25
       at new ManagedPromise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1077:7
       at ControlFlow.promise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2505:12
       at schedulerExecute C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:95:18
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at UserContext.<anonymous> C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:94:19
       at Suite.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:49:2
       at Object.<anonymous> C:\Users\martijn\iaf-gui-protractor\ladybug.spec.js:5:1
       at Module._compile node:internal/modules/cjs/loader:1101:14
       at Object.Module._extensions..js node:internal/modules/cjs/loader:1153:10
       at Module.load node:internal/modules/cjs/loader:981:32
       at Function.Module._load node:internal/modules/cjs/loader:822:12

5. Test A Pipeline Page tests : Should return a result after testing a pipeline
   Failed: Wait timed out after 100008ms
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2201:17
       at ManagedPromise.invokeCallback_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1376:14
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2927:27
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:668:7
       at runMicrotasks <anonymous>
       at processTicksAndRejections node:internal/process/task_queues:96:5
       at scheduleWait C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2188:20
       at ControlFlow.wait C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2517:12
       at Driver.wait C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:934:29
       at run C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\browser.js:58:33
       at ProtractorBrowser.to.<computed> [as wait] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\browser.js:66:16
       at UserContext.<anonymous> C:\Users\martijn\iaf-gui-protractor\test-pipeline.spec.js:12:17
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:112:25
       at new ManagedPromise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1077:7
       at ControlFlow.promise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2505:12
       at schedulerExecute C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:95:18
       at UserContext.<anonymous> C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:94:19
       at Suite.<anonymous> C:\Users\martijn\iaf-gui-protractor\test-pipeline.spec.js:9:5
       at Object.<anonymous> C:\Users\martijn\iaf-gui-protractor\test-pipeline.spec.js:4:1
       at Module._compile node:internal/modules/cjs/loader:1101:14
       at Object.Module._extensions..js node:internal/modules/cjs/loader:1153:10
       at Module.load node:internal/modules/cjs/loader:981:32
       at Function.Module._load node:internal/modules/cjs/loader:822:12

6. Test A Pipeline Page tests : Should return an alert message when testing a pipeline without selecting an adapter
   Failed: Wait timed out after 100038ms
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2201:17
       at ManagedPromise.invokeCallback_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1376:14
       at TaskQueue.execute_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3084:14
       at TaskQueue.executeNext_ C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:3067:27
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2927:27
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:668:7
       at runMicrotasks <anonymous>
       at processTicksAndRejections node:internal/process/task_queues:96:5
       at scheduleWait C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2188:20
       at ControlFlow.wait C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2517:12
       at Driver.wait C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver.js:934:29
       at run C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\browser.js:58:33
       at ProtractorBrowser.to.<computed> [as wait] C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\built\browser.js:66:16
       at UserContext.<anonymous> C:\Users\martijn\iaf-gui-protractor\test-pipeline.spec.js:12:17
       at C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:112:25
       at new ManagedPromise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:1077:7
       at ControlFlow.promise C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\selenium-webdriver\lib\promise.js:2505:12
       at schedulerExecute C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:95:18
       at UserContext.<anonymous> C:\Users\martijn\AppData\Roaming\npm\node_modules\protractor\node_modules\jasminewd2\index.js:94:19
       at Suite.<anonymous> C:\Users\martijn\iaf-gui-protractor\test-pipeline.spec.js:9:5
       at Object.<anonymous> C:\Users\martijn\iaf-gui-protractor\test-pipeline.spec.js:4:1
       at Module._compile node:internal/modules/cjs/loader:1101:14
       at Object.Module._extensions..js node:internal/modules/cjs/loader:1153:10
       at Module.load node:internal/modules/cjs/loader:981:32
       at Function.Module._load node:internal/modules/cjs/loader:822:12

Pending Specs:

1. Ladybug Page tests : Should give an error message in the test page when running a report after disabled the report generator
   Reason: Temporarily disabled with xit

Summary:

Suites:  5 of 5
Specs:   20 of 21 (1 pending)
Expects: 44 (7 failures)
Finished in 374.099 seconds

[12:49:23] I/launcher - 0 instance(s) of WebDriver still running
[12:49:23] I/launcher - chrome #01 failed 6 test(s)
[12:49:23] I/launcher - overall: 6 failed spec(s)
[12:49:23] E/launcher - Process exited with error code 1

```

I intend to ask help with this.